### PR TITLE
Amended vpc config in serverless to fix typo

### DIFF
--- a/ResidentInformationApi/serverless.yml
+++ b/ResidentInformationApi/serverless.yml
@@ -89,6 +89,6 @@ custom:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656
     production:
-      subnetId:
+      subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34


### PR DESCRIPTION
Fixing issue with lambda not being attached to VPC because of typo